### PR TITLE
Fix a typo in helloworld.go

### DIFF
--- a/examples/helloworld/helloworld.go
+++ b/examples/helloworld/helloworld.go
@@ -21,7 +21,7 @@ func main() {
 	flag.StringVar(&kbLoc, "keybase", "keybase", "the location of the Keybase app")
 	flag.Parse()
 
-	if kbc, err = kbchat.Start(kbachat.RunOptions{KeybaseLocation: kbLoc}); err != nil {
+	if kbc, err = kbchat.Start(kbchat.RunOptions{KeybaseLocation: kbLoc}); err != nil {
 		fail("Error creating API: %s", err.Error())
 	}
 


### PR DESCRIPTION
When I tried to run `helloworld.go`, I got an error about `kbachat` not being defined. Figured this was supposed to be `kbchat`. The file runs and sends "hello world" fine with this change.