### PR TITLE
Add three new methods to the kbchat object

### DIFF
--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -606,8 +606,8 @@ func (a *API) JoinChannel(teamName string, channelName string) error {
 	return err
 }
 
-func (a *API) ListMembersOfTeam(teamName string) (ListMembersResultMembers, error) {
-	empty := ListMembersResultMembers{}
+func (a *API) ListMembersOfTeam(teamName string) (ListTeamMembersResultMembers, error) {
+	empty := ListTeamMembersResultMembers{}
 
 	apiInput := fmt.Sprintf(`{"method": "list-team-memberships", "params": {"options": {"team": "%s"}}}`, teamName)
 	cmd := a.runOpts.Command("team", "api")
@@ -616,7 +616,8 @@ func (a *API) ListMembersOfTeam(teamName string) (ListMembersResultMembers, erro
 	if err != nil {
 		return empty, fmt.Errorf("failed to call keybase team api: %v", err)
 	}
-	members := ListMembers{}
+
+	members := ListTeamMembers{}
 	err = json.Unmarshal(bytes, &members)
 	if err != nil {
 		return empty, fmt.Errorf("failed to parse output from keybase team api: %v", err)
@@ -626,6 +627,29 @@ func (a *API) ListMembersOfTeam(teamName string) (ListMembersResultMembers, erro
 	}
 	return members.Result.Members, nil
 }
+
+func (a *API) ListUserMemberships(username string) ([]ListUserMembershipsResultTeam, error) {
+	empty := []ListUserMembershipsResultTeam{}
+
+	apiInput := fmt.Sprintf(`{"method": "list-user-memberships", "params": {"options": {"username": "%s"}}}`, username)
+	cmd := a.runOpts.Command("team", "api")
+	cmd.Stdin = strings.NewReader(apiInput)
+	bytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return empty, fmt.Errorf("failed to call keybase team api: %v", err)
+	}
+
+	members := ListUserMemberships{}
+	err = json.Unmarshal(bytes, &members)
+	if err != nil {
+		return empty, fmt.Errorf("failed to parse output from keybase team api: %v", err)
+	}
+	if members.Error.Message != "" {
+		return empty, fmt.Errorf("received error from keybase team api: %s", members.Error.Message)
+	}
+	return members.Result.Teams, nil
+}
+
 
 func (a *API) LogSend(feedback string) error {
 	feedback = "go-keybase-chat-bot log send\n" +

--- a/kbchat/team.go
+++ b/kbchat/team.go
@@ -1,0 +1,89 @@
+package kbchat
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type ListTeamMembers struct {
+	Result ListTeamMembersResult `json:"result"`
+	Error  Error             `json:"error"`
+}
+
+type ListTeamMembersResult struct {
+	Members ListTeamMembersResultMembers `json:"members"`
+}
+
+type ListTeamMembersResultMembers struct {
+	Owners  []ListMembersOutputMembersCategory `json:"owners"`
+	Admins  []ListMembersOutputMembersCategory `json:"admins"`
+	Writers []ListMembersOutputMembersCategory `json:"writers"`
+	Readers []ListMembersOutputMembersCategory `json:"readers"`
+}
+
+type ListMembersOutputMembersCategory struct {
+	Username string `json:"username"`
+	FullName string `json:"fullName"`
+}
+
+type ListUserMemberships struct {
+	Result ListUserMembershipsResult `json:"result"`
+	Error  Error             `json:"error"`
+}
+
+type ListUserMembershipsResult struct {
+	Teams []ListUserMembershipsResultTeam `json:"teams"`
+}
+
+type ListUserMembershipsResultTeam struct {
+	TeamName string `json:"fq_name"`
+	IsImplicitTeam bool `json:"is_implicit_team"`
+	IsOpenTeam bool `json:"is_open_team"`
+	Role int `json:"role"`
+	MemberCount int `json:"member_count"`
+}
+
+func (a *API) ListMembersOfTeam(teamName string) (ListTeamMembersResultMembers, error) {
+	empty := ListTeamMembersResultMembers{}
+
+	apiInput := fmt.Sprintf(`{"method": "list-team-memberships", "params": {"options": {"team": "%s"}}}`, teamName)
+	cmd := a.runOpts.Command("team", "api")
+	cmd.Stdin = strings.NewReader(apiInput)
+	bytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return empty, fmt.Errorf("failed to call keybase team api: %v", err)
+	}
+
+	members := ListTeamMembers{}
+	err = json.Unmarshal(bytes, &members)
+	if err != nil {
+		return empty, fmt.Errorf("failed to parse output from keybase team api: %v", err)
+	}
+	if members.Error.Message != "" {
+		return empty, fmt.Errorf("received error from keybase team api: %s", members.Error.Message)
+	}
+	return members.Result.Members, nil
+}
+
+func (a *API) ListUserMemberships(username string) ([]ListUserMembershipsResultTeam, error) {
+	empty := []ListUserMembershipsResultTeam{}
+
+	apiInput := fmt.Sprintf(`{"method": "list-user-memberships", "params": {"options": {"username": "%s"}}}`, username)
+	cmd := a.runOpts.Command("team", "api")
+	cmd.Stdin = strings.NewReader(apiInput)
+	bytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return empty, fmt.Errorf("failed to call keybase team api: %v", err)
+	}
+
+	members := ListUserMemberships{}
+	err = json.Unmarshal(bytes, &members)
+	if err != nil {
+		return empty, fmt.Errorf("failed to parse output from keybase team api: %v", err)
+	}
+	if members.Error.Message != "" {
+		return empty, fmt.Errorf("received error from keybase team api: %s", members.Error.Message)
+	}
+	return members.Result.Teams, nil
+}

--- a/kbchat/types.go
+++ b/kbchat/types.go
@@ -128,45 +128,23 @@ type Advertisement struct {
 	Advertisements []CommandsAdvertisement
 }
 
-type ListTeamMembers struct {
-	Result ListTeamMembersResult `json:"result"`
-	Error  TeamError             `json:"error"`
-}
-
-type TeamError struct {
+type Error struct {
 	Code int `json:"code"`
 	Message string `json:"message"`
 }
 
-type ListTeamMembersResult struct {
-	Members ListTeamMembersResultMembers `json:"members"`
+type JoinChannel struct {
+	Error Error `json:"error"`
+	Result JoinChannelResult `json:"result"`
 }
 
-type ListTeamMembersResultMembers struct {
-	Owners  []ListMembersOutputMembersCategory `json:"owners"`
-	Admins  []ListMembersOutputMembersCategory `json:"admins"`
-	Writers []ListMembersOutputMembersCategory `json:"writers"`
-	Readers []ListMembersOutputMembersCategory `json:"readers"`
+type JoinChannelResult struct {
+	RateLimit RateLimit `json:"ratelimits"`
 }
 
-type ListMembersOutputMembersCategory struct {
-	Username string `json:"username"`
-	FullName string `json:"fullName"`
-}
-
-type ListUserMemberships struct {
-	Result ListUserMembershipsResult `json:"result"`
-	Error  TeamError             `json:"error"`
-}
-
-type ListUserMembershipsResult struct {
-	Teams []ListUserMembershipsResultTeam `json:"teams"`
-}
-
-type ListUserMembershipsResultTeam struct {
-	TeamName string `json:"fq_name"`
-	IsImplicitTeam bool `json:"is_implicit_team"`
-	IsOpenTeam bool `json:"is_open_team"`
-	Role int `json:"role"`
-	MemberCount int `json:"member_count"`
+type RateLimit struct {
+	Tank string `json:"tank"`
+	Capacity int `json:"capacity"`
+	Reset int `json:"reset"`
+	Gas int `json:"gas"`
 }

--- a/kbchat/types.go
+++ b/kbchat/types.go
@@ -128,9 +128,9 @@ type Advertisement struct {
 	Advertisements []CommandsAdvertisement
 }
 
-type ListMembers struct {
-	Result ListMembersResult `json:"result"`
-	Error TeamError `json:"error"`
+type ListTeamMembers struct {
+	Result ListTeamMembersResult `json:"result"`
+	Error  TeamError             `json:"error"`
 }
 
 type TeamError struct {
@@ -138,11 +138,11 @@ type TeamError struct {
 	Message string `json:"message"`
 }
 
-type ListMembersResult struct {
-	Members ListMembersResultMembers `json:"members"`
+type ListTeamMembersResult struct {
+	Members ListTeamMembersResultMembers `json:"members"`
 }
 
-type ListMembersResultMembers struct {
+type ListTeamMembersResultMembers struct {
 	Owners  []ListMembersOutputMembersCategory `json:"owners"`
 	Admins  []ListMembersOutputMembersCategory `json:"admins"`
 	Writers []ListMembersOutputMembersCategory `json:"writers"`
@@ -152,4 +152,21 @@ type ListMembersResultMembers struct {
 type ListMembersOutputMembersCategory struct {
 	Username string `json:"username"`
 	FullName string `json:"fullName"`
+}
+
+type ListUserMemberships struct {
+	Result ListUserMembershipsResult `json:"result"`
+	Error  TeamError             `json:"error"`
+}
+
+type ListUserMembershipsResult struct {
+	Teams []ListUserMembershipsResultTeam `json:"teams"`
+}
+
+type ListUserMembershipsResultTeam struct {
+	TeamName string `json:"fq_name"`
+	IsImplicitTeam bool `json:"is_implicit_team"`
+	IsOpenTeam bool `json:"is_open_team"`
+	Role int `json:"role"`
+	MemberCount int `json:"member_count"`
 }

--- a/kbchat/types.go
+++ b/kbchat/types.go
@@ -45,6 +45,10 @@ type Inbox struct {
 	Result Result `json:"result"`
 }
 
+type ChannelsList struct {
+	Result Result `json:"result"`
+}
+
 type MsgPaymentDetails struct {
 	ResultType int    `json:"resultTyp"` // 0 good. 1 error
 	PaymentID  string `json:"sent"`
@@ -122,4 +126,30 @@ type CommandsAdvertisement struct {
 type Advertisement struct {
 	Alias          string `json:"alias,omitempty"`
 	Advertisements []CommandsAdvertisement
+}
+
+type ListMembers struct {
+	Result ListMembersResult `json:"result"`
+	Error TeamError `json:"error"`
+}
+
+type TeamError struct {
+	Code int `json:"code"`
+	Message string `json:"message"`
+}
+
+type ListMembersResult struct {
+	Members ListMembersResultMembers `json:"members"`
+}
+
+type ListMembersResultMembers struct {
+	Owners  []ListMembersOutputMembersCategory `json:"owners"`
+	Admins  []ListMembersOutputMembersCategory `json:"admins"`
+	Writers []ListMembersOutputMembersCategory `json:"writers"`
+	Readers []ListMembersOutputMembersCategory `json:"readers"`
+}
+
+type ListMembersOutputMembersCategory struct {
+	Username string `json:"username"`
+	FullName string `json:"fullName"`
 }


### PR DESCRIPTION
Added `ListChannels`, `JoinChannel`, and `ListMembersOfTeam`. These three method definitions originally lived in the SSH CA bot but moving them over in order to expand the library. 

Tested by migrating the SSH CA bot to calling them and running the integration tests. 