### PR TITLE
Add scaffolding to test bot functions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kbchat/test_config.yaml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Script Keybase Chat in Go!
 
 This module is a side-project/work in progress and may change or have crashers, but feel free to play with it. As long as you're logged in as a Keybase user, you can use this module to script basic chat commands.
 
-# Installation
+## Installation
 
 Make sure to [install Keybase](https://keybase.io/download).
 
@@ -154,13 +154,16 @@ Returns the same object as above, but this one will have another channel on it t
 	}
 ```
 
-
-
 ## TODO:
-  - attachment handling (posting/getting)
-  - edit/delete
-  - many other things!
 
-### Contributions
+- attachment handling (posting/getting)
+- edit/delete
+- many other things!
+
+## Contributions
 
 - welcomed!
+
+### Testing
+
+You'll need to have a few demo bot accounts and teams to run the suite of tests. Make a copy of `kbchat/test_config.example.yaml`, rename it to `kbchat/test_config.yaml`, and replace the example data with your own. Tests can then be run inside of `kbchat/` with `go test`.

--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -651,3 +651,21 @@ func (a *API) LogSend(feedback string) error {
 
 	return a.runOpts.Command(args...).Run()
 }
+
+func (a *API) Shutdown() error {
+	if a.runOpts.Oneshot != nil {
+		err := a.runOpts.Command("logout", "--force").Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	if a.runOpts.StartService {
+		err := a.runOpts.Command("ctl", "stop", "--shutdown").Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -137,9 +137,7 @@ func (a *API) startPipes() (err error) {
 	a.apiCmd = nil
 
 	if a.runOpts.StartService {
-		go func() {
-			a.runOpts.Command("service").Run()
-		}()
+		a.runOpts.Command("service").Start()
 	}
 
 	if a.username, err = a.auth(); err != nil {

--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -140,7 +140,6 @@ func (a *API) startPipes() (err error) {
 		go func() {
 			a.runOpts.Command("service").Run()
 		}()
-		time.Sleep(3 * time.Second)
 	}
 
 	if a.username, err = a.auth(); err != nil {

--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -70,6 +70,7 @@ type RunOptions struct {
 	KeybaseLocation string
 	HomeDir         string
 	Oneshot         *OneshotOptions
+	StartService    bool
 }
 
 func (r RunOptions) Location() string {
@@ -121,6 +122,7 @@ func (a *API) auth() (string, error) {
 			a.runOpts.Oneshot.PaperKey).Run(); err != nil {
 			return "", err
 		}
+		username = a.runOpts.Oneshot.Username
 		return username, nil
 	}
 	return "", errors.New("unable to auth")
@@ -133,6 +135,14 @@ func (a *API) startPipes() (err error) {
 		a.apiCmd.Process.Kill()
 	}
 	a.apiCmd = nil
+
+	if a.runOpts.StartService {
+		go func() {
+			a.runOpts.Command("service").Run()
+		}()
+		time.Sleep(3 * time.Second)
+	}
+
 	if a.username, err = a.auth(); err != nil {
 		return err
 	}

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -99,6 +99,10 @@ func prepWorkingDir(workingDir string) (string, error) {
 	return kbDestination, nil
 }
 
+func deleteWorkingDir(workingDir string) error {
+	return os.RemoveAll("/tmp/")
+}
+
 var kbc *API
 
 func TestMain(m *testing.M) {
@@ -125,6 +129,10 @@ func TestMain(m *testing.M) {
 	err = kbc.Shutdown()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error on service shutdown: %v\n", err)
+	}
+	err = deleteWorkingDir(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error working directory teardown: %v\n", err)
 	}
 	os.Exit(code)
 }

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -105,10 +105,15 @@ func TestSendMessageByTlfName(t *testing.T) {
 	require.NoError(t, err)
 	kbLocation, err := prepWorkingDir(dir)
 	require.NoError(t, err)
+
 	kbc, err := Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots.Alice1, StartService: true})
 	require.NoError(t, err, "error %s")
+
 	tlfName := fmt.Sprintf("%s,%s", kbc.Username(), "kb_monbot")
 	res, err := kbc.SendMessageByTlfName(tlfName, "test")
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
+
+	err = kbc.Shutdown()
+	require.NoError(t, err)
 }

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -1,13 +1,46 @@
 package kbchat
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
+
+type Bots struct {
+	Alice1   *OneshotOptions
+	Alice2   *OneshotOptions
+	Bob1     *OneshotOptions
+	Charlie1 *OneshotOptions
+}
+
+type Config struct {
+	Bots
+}
+
+func readAndParseConfig() (Config, error) {
+	var config Config
+	data, err := ioutil.ReadFile("test_config.yaml")
+	if err != nil {
+		return Config{}, err
+	}
+
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return config, nil
+}
 
 func randomTempDir() (string, error) {
 	bytes := make([]byte, 16)
@@ -19,7 +52,63 @@ func randomTempDir() (string, error) {
 	return dir, nil
 }
 
-func TestListChannels(t *testing.T) {
-	dir, _ := randomTempDir()
-	fmt.Printf("randomTempDir() = %+v\n", dir)
+func whichKeybase() (string, error) {
+	cmd := exec.Command("which", "keybase")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	location := strings.TrimSpace(out.String())
+	return location, nil
+}
+
+func copyFile(source, dest string) error {
+	sourceData, err := ioutil.ReadFile(source)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(dest, sourceData, 0777)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func prepWorkingDir(workingDir string) (string, error) {
+	kbLocation, err := whichKeybase()
+	if err != nil {
+		return "", err
+	}
+
+	err = os.Mkdir(workingDir, 0777)
+	if err != nil {
+		return "", err
+	}
+	kbDestination := path.Join(workingDir, "keybase")
+
+	err = copyFile(kbLocation, kbDestination)
+	if err != nil {
+		return "", err
+	}
+
+	return kbDestination, nil
+}
+
+func TestSendMessageByTlfName(t *testing.T) {
+	config, err := readAndParseConfig()
+	require.NoError(t, err)
+	dir, err := randomTempDir()
+	require.NoError(t, err)
+	kbLocation, err := prepWorkingDir(dir)
+	require.NoError(t, err)
+	kbc, err := Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots.Alice1, StartService: true})
+	require.NoError(t, err, "error %s")
+	tlfName := fmt.Sprintf("%s,%s", kbc.Username(), "kb_monbot")
+	res, err := kbc.SendMessageByTlfName(tlfName, "test")
+	require.NoError(t, err)
+	require.Greater(t, res.Result.MsgID, 0)
 }

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -104,9 +104,11 @@ func deleteWorkingDir(workingDir string) error {
 }
 
 var kbc *API
+var config Config
 
 func TestMain(m *testing.M) {
-	config, err := readAndParseConfig()
+	var err error
+	config, err = readAndParseConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error in reading config: %v\n", err)
 	}
@@ -137,9 +139,46 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestGetUsername(t *testing.T) {
+	require.Equal(t, kbc.GetUsername(), config.Bots.Alice1.Username)
+}
+
+func TestGetConversations(t *testing.T) {
+	conversations, err := kbc.GetConversations(false)
+	require.NoError(t, err)
+	require.Greater(t, len(conversations), 0)
+}
+
+func TestGetTextMessages(t *testing.T) {
+	channel := Channel{
+		Name: fmt.Sprintf("%s,%s", config.Bots.Alice1.Username, config.Bots.Charlie1.Username),
+	}
+	messages, err := kbc.GetTextMessages(channel, false)
+	require.NoError(t, err)
+	require.Greater(t, len(messages), 0)
+}
+
+func TestSendMessage(t *testing.T) {}
+
+func TestSendMessageByConvID(t *testing.T) {}
+
 func TestSendMessageByTlfName(t *testing.T) {
 	tlfName := fmt.Sprintf("%s,%s", kbc.Username(), "kb_monbot")
 	res, err := kbc.SendMessageByTlfName(tlfName, "test")
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 }
+
+func TestSendMessageByTeamName(t *testing.T) {}
+
+func TestSendAttachmentByTeam(t *testing.T) {}
+
+func TestReactByChannel(t *testing.T) {}
+
+func TestReactByConvID(t *testing.T) {}
+
+func TestAdvertiseCommands(t *testing.T) {}
+
+func TestListChannels(t *testing.T) {}
+
+func TestJoinChannel(t *testing.T) {}

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -100,7 +100,7 @@ func prepWorkingDir(workingDir string) (string, error) {
 }
 
 func deleteWorkingDir(workingDir string) error {
-	return os.RemoveAll("/tmp/")
+	return os.RemoveAll(workingDir)
 }
 
 var kbc *API

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -1,7 +1,6 @@
 package kbchat
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -54,13 +53,12 @@ func randomTempDir() (string, error) {
 
 func whichKeybase() (string, error) {
 	cmd := exec.Command("which", "keybase")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
+
+	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
-	location := strings.TrimSpace(out.String())
+	location := strings.TrimSpace(string(out))
 	return location, nil
 }
 

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -77,6 +77,8 @@ func copyFile(source, dest string) error {
 	return nil
 }
 
+// Creates the working directory and copies over the keybase binary in PATH.
+// We do this to avoid any version mismatch issues.
 func prepWorkingDir(workingDir string) (string, error) {
 	kbLocation, err := whichKeybase()
 	if err != nil {

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -1,0 +1,25 @@
+package kbchat
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+)
+
+func randomTempDir() (string, error) {
+	bytes := make([]byte, 16)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", err
+	}
+	dir := path.Join(os.TempDir(), "keybase_bot_"+hex.EncodeToString(bytes))
+	return dir, nil
+}
+
+func TestListChannels(t *testing.T) {
+	dir, _ := randomTempDir()
+	fmt.Printf("randomTempDir() = %+v\n", dir)
+}

--- a/kbchat/test_config.example.yaml
+++ b/kbchat/test_config.example.yaml
@@ -1,0 +1,20 @@
+# Rename this file to `test_config.yaml`
+
+config:
+  bots:
+    alice1:
+      # Alice should have an active Stellar account with a little bit of XLM in it
+      username: "alice"
+      paperkey: "foo bar car..."
+    }
+    alice2:
+      username: "alice"                # should be the same username as alice1 but...
+      paperkey: "yo there paperkey..." # ...this should be a DIFFERENT paperkey than the one for alice1
+    bob1:
+      # Bob should have an active Stellar account with a little bit of XLM in it
+      username: "bob"
+      paperkey: "one two three four..."
+    charlie1:
+      # Charlie should be an account that does not have access to Stellar features
+      username: "charlie"
+      paperkey: "get this bread..."

--- a/kbchat/test_config.example.yaml
+++ b/kbchat/test_config.example.yaml
@@ -6,7 +6,6 @@ config:
       # Alice should have an active Stellar account with a little bit of XLM in it
       username: "alice"
       paperkey: "foo bar car..."
-    }
     alice2:
       username: "alice"                # should be the same username as alice1 but...
       paperkey: "yo there paperkey..." # ...this should be a DIFFERENT paperkey than the one for alice1
@@ -15,6 +14,13 @@ config:
       username: "bob"
       paperkey: "one two three four..."
     charlie1:
-      # Charlie should be an account that does not have access to Stellar features
+      # Charlie should be an account that has not accepted the Stellar disclaimer yet
       username: "charlie"
       paperkey: "get this bread..."
+  teams:
+    acme:
+      # A real team that you add your alice1, alice2, and bob1 all into
+      teamname: "acme"
+    alicesPlayground:
+      # a team with alice in it AS ADMIN, but bob or charlie not in team
+      teamname: "alices_playground"


### PR DESCRIPTION
Tests are pretty similar to how the TypeScript bot does it; it spins up a new service in a temp directory. 

Also introduces a `StartService` option to `RunOptions` to start the service and a `Shutdown` function to logout and stop the service.