### PR TITLE
Test most of the kbchat functions

### DIFF
--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -642,7 +642,7 @@ func (a *API) LeaveChannel(teamName string, channelName string) (LeaveChannelRes
 	}
 
 	leaveChannel := LeaveChannel{}
-	err = json.Unmarshal([]byte(output.Text()[:]), &leaveChannel)
+	err = json.Unmarshal(output, &leaveChannel)
 	if err != nil {
 		return empty, fmt.Errorf("failed to parse output from keybase team api: %v", err)
 	}

--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -632,6 +632,27 @@ func (a *API) JoinChannel(teamName string, channelName string) (JoinChannelResul
 	return joinChannel.Result, nil
 }
 
+func (a *API) LeaveChannel(teamName string, channelName string) (LeaveChannelResult, error) {
+	empty := LeaveChannelResult{}
+
+	apiInput := fmt.Sprintf(`{"method": "leave", "params": {"options": {"channel": {"name": "%s", "members_type": "team", "topic_name": "%s"}}}}`, teamName, channelName)
+	output, err := a.doFetch(apiInput)
+	if err != nil {
+		return empty, err
+	}
+
+	leaveChannel := LeaveChannel{}
+	err = json.Unmarshal([]byte(output.Text()[:]), &leaveChannel)
+	if err != nil {
+		return empty, fmt.Errorf("failed to parse output from keybase team api: %v", err)
+	}
+	if leaveChannel.Error.Message != "" {
+		return empty, fmt.Errorf("received error from keybase team api: %s", leaveChannel.Error.Message)
+	}
+
+	return leaveChannel.Result, nil
+}
+
 func (a *API) LogSend(feedback string) error {
 	feedback = "go-keybase-chat-bot log send\n" +
 		"username: " + a.GetUsername() + "\n" +

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -18,38 +18,38 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type Bots struct {
+type bots struct {
 	Alice1   *OneshotOptions
 	Alice2   *OneshotOptions
 	Bob1     *OneshotOptions
 	Charlie1 *OneshotOptions
 }
 
-type Team struct {
+type team struct {
 	Teamname string
 	Channel  string
 }
 
-type Teams struct {
-	Acme             Team
-	AlicesPlayground Team
+type teams struct {
+	Acme             team
+	AlicesPlayground team
 }
 
-type Config struct {
-	Bots
-	Teams
+type botConfig struct {
+	Bots  bots
+	Teams teams
 }
 
-func readAndParseConfig() (Config, error) {
-	var config Config
+func readAndParseConfig() (botConfig, error) {
+	var config botConfig
 	data, err := ioutil.ReadFile("test_config.yaml")
 	if err != nil {
-		return Config{}, err
+		return botConfig{}, err
 	}
 
 	err = yaml.Unmarshal(data, &config)
 	if err != nil {
-		return Config{}, err
+		return botConfig{}, err
 	}
 
 	return config, nil
@@ -117,7 +117,7 @@ func deleteWorkingDir(workingDir string) error {
 }
 
 var alice *API
-var config Config
+var config botConfig
 var channel Channel
 var teamChannel Channel
 

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -356,7 +356,7 @@ func TestListenForNewTextMessages(t *testing.T) {
 
 	go func() {
 		for i := 0; i < 5; i++ {
-			time.Sleep(3 * time.Second)
+			time.Sleep(time.Second)
 			_, err := bob.SendMessage(channel, text+" "+strconv.Itoa(i))
 			require.NoError(t, err)
 		}

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -191,10 +191,10 @@ func TestSendMessage(t *testing.T) {
 	// Read it to confirm it sent
 	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
-	sentMessage := messages[0]
-	require.Equal(t, sentMessage.Content.Type, "text")
-	require.Equal(t, sentMessage.Content.Text.Body, text)
-	require.Equal(t, sentMessage.MsgID, res.Result.MsgID)
+	readMessage := messages[0]
+	require.Equal(t, readMessage.Content.Type, "text")
+	require.Equal(t, readMessage.Content.Text.Body, text)
+	require.Equal(t, readMessage.MsgID, res.Result.MsgID)
 }
 
 func TestSendMessageByConvID(t *testing.T) {
@@ -215,10 +215,10 @@ func TestSendMessageByConvID(t *testing.T) {
 	// Read it to confirm it sent
 	messages, err = alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
-	sentMessage := messages[0]
-	require.Equal(t, sentMessage.Content.Type, "text")
-	require.Equal(t, sentMessage.Content.Text.Body, text)
-	require.Equal(t, sentMessage.MsgID, res.Result.MsgID)
+	readMessage := messages[0]
+	require.Equal(t, readMessage.Content.Type, "text")
+	require.Equal(t, readMessage.Content.Text.Body, text)
+	require.Equal(t, readMessage.MsgID, res.Result.MsgID)
 }
 
 func TestSendMessageByTlfName(t *testing.T) {
@@ -234,10 +234,10 @@ func TestSendMessageByTlfName(t *testing.T) {
 	// Read it to confirm it sent
 	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
-	sentMessage := messages[0]
-	require.Equal(t, sentMessage.Content.Type, "text")
-	require.Equal(t, sentMessage.Content.Text.Body, text)
-	require.Equal(t, sentMessage.MsgID, res.Result.MsgID)
+	readMessage := messages[0]
+	require.Equal(t, readMessage.Content.Type, "text")
+	require.Equal(t, readMessage.Content.Text.Body, text)
+	require.Equal(t, readMessage.MsgID, res.Result.MsgID)
 }
 
 func TestSendMessageByTeamName(t *testing.T) {
@@ -253,10 +253,10 @@ func TestSendMessageByTeamName(t *testing.T) {
 	// Read it to confirm it sent
 	messages, err := alice.GetTextMessages(teamChannel, false)
 	require.NoError(t, err)
-	sentMessage := messages[0]
-	require.Equal(t, sentMessage.Content.Type, "text")
-	require.Equal(t, sentMessage.Content.Text.Body, text)
-	require.Equal(t, sentMessage.MsgID, res.Result.MsgID)
+	readMessage := messages[0]
+	require.Equal(t, readMessage.Content.Type, "text")
+	require.Equal(t, readMessage.Content.Text.Body, text)
+	require.Equal(t, readMessage.MsgID, res.Result.MsgID)
 }
 
 func TestSendAttachmentByTeam(t *testing.T) {
@@ -274,15 +274,6 @@ func TestSendAttachmentByTeam(t *testing.T) {
 	res, err := alice.SendAttachmentByTeam(teamChannel.Name, location, title, &teamChannel.TopicName)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
-
-	// Types don't support attachments yet, so we can't read it
-	// Read it to confirm it sent
-	// messages, err := alice.GetTextMessages(teamChannel, false)
-	// require.NoError(t, err)
-	// sentMessage := messages[0]
-	// require.Equal(t, sentMessage.Content.Type, "attachment")
-	// require.Equal(t, sentMessage.Content.Attachment.Object.Title, title)
-	// require.Equal(t, sentMessage.MsgID, res.Result.MsgID)
 }
 
 func TestReactByChannel(t *testing.T) {

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -167,7 +167,7 @@ func TestGetConversations(t *testing.T) {
 	defer testTeardown(alice, dir)
 	conversations, err := alice.GetConversations(false)
 	require.NoError(t, err)
-	require.Greater(t, len(conversations), 0)
+	require.True(t, len(conversations) > 0)
 }
 
 func TestGetTextMessages(t *testing.T) {
@@ -175,7 +175,7 @@ func TestGetTextMessages(t *testing.T) {
 	defer testTeardown(alice, dir)
 	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
-	require.Greater(t, len(messages), 0)
+	require.True(t, len(messages) > 0)
 }
 
 func TestSendMessage(t *testing.T) {
@@ -186,7 +186,7 @@ func TestSendMessage(t *testing.T) {
 	// Send the message
 	res, err := alice.SendMessage(oneOnOneChannel, text)
 	require.NoError(t, err)
-	require.Greater(t, res.Result.MsgID, 0)
+	require.True(t, res.Result.MsgID > 0)
 
 	// Read it to confirm it sent
 	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
@@ -210,7 +210,7 @@ func TestSendMessageByConvID(t *testing.T) {
 	// Send the message
 	res, err := alice.SendMessageByConvID(convID, text)
 	require.NoError(t, err)
-	require.Greater(t, res.Result.MsgID, 0)
+	require.True(t, res.Result.MsgID > 0)
 
 	// Read it to confirm it sent
 	messages, err = alice.GetTextMessages(oneOnOneChannel, false)
@@ -229,7 +229,7 @@ func TestSendMessageByTlfName(t *testing.T) {
 	// Send the message
 	res, err := alice.SendMessageByTlfName(oneOnOneChannel.Name, text)
 	require.NoError(t, err)
-	require.Greater(t, res.Result.MsgID, 0)
+	require.True(t, res.Result.MsgID > 0)
 
 	// Read it to confirm it sent
 	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
@@ -248,7 +248,7 @@ func TestSendMessageByTeamName(t *testing.T) {
 	// Send the message
 	res, err := alice.SendMessageByTeamName(teamChannel.Name, text, &teamChannel.TopicName)
 	require.NoError(t, err)
-	require.Greater(t, res.Result.MsgID, 0)
+	require.True(t, res.Result.MsgID > 0)
 
 	// Read it to confirm it sent
 	messages, err := alice.GetTextMessages(teamChannel, false)
@@ -273,7 +273,7 @@ func TestSendAttachmentByTeam(t *testing.T) {
 	title := "test SendAttachmentByTeam " + randomString()
 	res, err := alice.SendAttachmentByTeam(teamChannel.Name, location, title, &teamChannel.TopicName)
 	require.NoError(t, err)
-	require.Greater(t, res.Result.MsgID, 0)
+	require.True(t, res.Result.MsgID > 0)
 }
 
 func TestReactByChannel(t *testing.T) {
@@ -288,7 +288,7 @@ func TestReactByChannel(t *testing.T) {
 	// Send the react
 	res, err := alice.ReactByChannel(oneOnOneChannel, lastMessageID, react)
 	require.NoError(t, err)
-	require.Greater(t, res.Result.MsgID, 0)
+	require.True(t, res.Result.MsgID > 0)
 }
 
 func TestReactByConvID(t *testing.T) {
@@ -309,7 +309,7 @@ func TestReactByConvID(t *testing.T) {
 	// Send the react
 	res, err := alice.ReactByConvID(convID, lastMessageID, react)
 	require.NoError(t, err)
-	require.Greater(t, res.Result.MsgID, 0)
+	require.True(t, res.Result.MsgID > 0)
 }
 
 func TestAdvertiseCommands(t *testing.T) {}
@@ -319,7 +319,7 @@ func TestListChannels(t *testing.T) {
 	defer testTeardown(alice, dir)
 	channels, err := alice.ListChannels(teamChannel.Name)
 	require.NoError(t, err)
-	require.Greater(t, len(channels), 0)
+	require.True(t, len(channels) > 0)
 	channelFound := false
 	for _, channel := range channels {
 		if channel == teamChannel.TopicName {

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -17,26 +17,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type bots struct {
-	Alice1   *OneshotOptions
-	Alice2   *OneshotOptions
-	Bob1     *OneshotOptions
-	Charlie1 *OneshotOptions
-}
-
 type team struct {
 	Teamname string
 	Channel  string
 }
 
-type teams struct {
-	Acme             team
-	AlicesPlayground team
-}
-
 type botConfig struct {
-	Bots  bots
-	Teams teams
+	Bots  map[string]*OneshotOptions
+	Teams map[string]team
 }
 
 func readAndParseConfig() (botConfig, error) {
@@ -129,19 +117,19 @@ func testSetup() (alice *API, config botConfig, dir string, oneOnOneChannel Chan
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error in preparing working directory: %v\n", err)
 	}
-	alice, err = Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots.Alice1, StartService: true})
+	alice, err = Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots["alice1"], StartService: true})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error in starting service: %v\n", err)
 	}
 
 	oneOnOneChannel = Channel{
-		Name: fmt.Sprintf("%s,%s", config.Bots.Alice1.Username, config.Bots.Charlie1.Username),
+		Name: fmt.Sprintf("%s,%s", config.Bots["alice1"].Username, config.Bots["charlie1"].Username),
 	}
 	teamChannel = Channel{
-		Name:        config.Teams.Acme.Teamname,
+		Name:        config.Teams["acme"].Teamname,
 		Public:      false,
 		MembersType: "team",
-		TopicName:   config.Teams.Acme.Channel,
+		TopicName:   config.Teams["acme"].Channel,
 		TopicType:   "chat",
 	}
 
@@ -161,7 +149,7 @@ func testTeardown(alice *API, dir string) {
 
 func TestGetUsername(t *testing.T) {
 	alice, config, dir, _, _ := testSetup()
-	require.Equal(t, alice.GetUsername(), config.Bots.Alice1.Username)
+	require.Equal(t, alice.GetUsername(), config.Bots["alice1"].Username)
 	testTeardown(alice, dir)
 }
 
@@ -364,7 +352,7 @@ func TestListenForNewTextMessages(t *testing.T) {
 	require.NoError(t, err)
 	kbLocation, err := prepWorkingDir(dir)
 	require.NoError(t, err)
-	bob, err := Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots.Bob1, StartService: true})
+	bob, err := Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots["bob1"], StartService: true})
 	require.NoError(t, err)
 
 	sub, err := alice.ListenForNewTextMessages()

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -122,12 +122,12 @@ func testSetup(botName string, options *testSetupOptions) (bot *API, config botC
 	dir = randomTempDir()
 	kbLocation, err := prepWorkingDir(dir)
 	if err != nil {
-		deleteWorkingDir(dir)
+		defer deleteWorkingDir(dir)
 		panic(err)
 	}
 	bot, err = Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots[botName], StartService: true})
 	if err != nil {
-		testTeardown(bot, dir)
+		defer testTeardown(bot, dir)
 		panic(err)
 	}
 

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -369,4 +369,6 @@ func TestListenForNewTextMessages(t *testing.T) {
 		require.Equal(t, msg.Message.Sender.Username, bob.GetUsername())
 		require.Equal(t, msg.Message.Content.Text.Body, text+" "+strconv.Itoa(i))
 	}
+
+	sub.Shutdown()
 }

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -9,8 +9,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -114,7 +116,7 @@ func deleteWorkingDir(workingDir string) error {
 	return os.RemoveAll(workingDir)
 }
 
-var kbc *API
+var alice *API
 var config Config
 var channel Channel
 var teamChannel Channel
@@ -133,7 +135,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error in preparing working directory: %v\n", err)
 	}
-	kbc, err = Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots.Alice1, StartService: true})
+	alice, err = Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots.Alice1, StartService: true})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error in starting service: %v\n", err)
 	}
@@ -152,7 +154,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	code := m.Run()
 
-	err = kbc.Shutdown()
+	err = alice.Shutdown()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error on service shutdown: %v\n", err)
 	}
@@ -164,17 +166,17 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetUsername(t *testing.T) {
-	require.Equal(t, kbc.GetUsername(), config.Bots.Alice1.Username)
+	require.Equal(t, alice.GetUsername(), config.Bots.Alice1.Username)
 }
 
 func TestGetConversations(t *testing.T) {
-	conversations, err := kbc.GetConversations(false)
+	conversations, err := alice.GetConversations(false)
 	require.NoError(t, err)
 	require.Greater(t, len(conversations), 0)
 }
 
 func TestGetTextMessages(t *testing.T) {
-	messages, err := kbc.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(channel, false)
 	require.NoError(t, err)
 	require.Greater(t, len(messages), 0)
 }
@@ -183,12 +185,12 @@ func TestSendMessage(t *testing.T) {
 	text := "test SendMessage"
 
 	// Send the message
-	res, err := kbc.SendMessage(channel, text)
+	res, err := alice.SendMessage(channel, text)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
 	// Read it to confirm it sent
-	messages, err := kbc.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(channel, false)
 	require.NoError(t, err)
 	sentMessage := messages[0]
 	require.Equal(t, sentMessage.Content.Type, "text")
@@ -200,16 +202,16 @@ func TestSendMessageByConvID(t *testing.T) {
 	text := "test SendMessageByConvID"
 
 	// Retrieve conversation ID
-	messages, err := kbc.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(channel, false)
 	convID := messages[0].ConversationID
 
 	// Send the message
-	res, err := kbc.SendMessageByConvID(convID, text)
+	res, err := alice.SendMessageByConvID(convID, text)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
 	// Read it to confirm it sent
-	messages, err = kbc.GetTextMessages(channel, false)
+	messages, err = alice.GetTextMessages(channel, false)
 	require.NoError(t, err)
 	sentMessage := messages[0]
 	require.Equal(t, sentMessage.Content.Type, "text")
@@ -221,12 +223,12 @@ func TestSendMessageByTlfName(t *testing.T) {
 	text := "test SendMessageByTlfName"
 
 	// Send the message
-	res, err := kbc.SendMessageByTlfName(channel.Name, text)
+	res, err := alice.SendMessageByTlfName(channel.Name, text)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
 	// Read it to confirm it sent
-	messages, err := kbc.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(channel, false)
 	require.NoError(t, err)
 	sentMessage := messages[0]
 	require.Equal(t, sentMessage.Content.Type, "text")
@@ -238,12 +240,12 @@ func TestSendMessageByTeamName(t *testing.T) {
 	text := "test SendMessageByTeamName"
 
 	// Send the message
-	res, err := kbc.SendMessageByTeamName(teamChannel.Name, text, &teamChannel.TopicName)
+	res, err := alice.SendMessageByTeamName(teamChannel.Name, text, &teamChannel.TopicName)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
 	// Read it to confirm it sent
-	messages, err := kbc.GetTextMessages(teamChannel, false)
+	messages, err := alice.GetTextMessages(teamChannel, false)
 	fmt.Printf("messages = %+v\n", messages)
 	require.NoError(t, err)
 	sentMessage := messages[0]
@@ -263,13 +265,13 @@ func TestSendAttachmentByTeam(t *testing.T) {
 
 	// Send the message
 	title := "test SendAttachmentByTeam"
-	res, err := kbc.SendAttachmentByTeam(teamChannel.Name, location, title, &teamChannel.TopicName)
+	res, err := alice.SendAttachmentByTeam(teamChannel.Name, location, title, &teamChannel.TopicName)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
 	// Types don't support attachments yet, so we can't read it
 	// Read it to confirm it sent
-	// messages, err := kbc.GetTextMessages(teamChannel, false)
+	// messages, err := alice.GetTextMessages(teamChannel, false)
 	// require.NoError(t, err)
 	// sentMessage := messages[0]
 	// require.Equal(t, sentMessage.Content.Type, "attachment")
@@ -280,12 +282,12 @@ func TestSendAttachmentByTeam(t *testing.T) {
 func TestReactByChannel(t *testing.T) {
 	react := ":cool:"
 	// Get last message, we'll react to it
-	messages, err := kbc.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(channel, false)
 	require.NoError(t, err)
 	lastMessageID := messages[0].MsgID
 
 	// Send the react
-	res, err := kbc.ReactByChannel(channel, lastMessageID, react)
+	res, err := alice.ReactByChannel(channel, lastMessageID, react)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
@@ -296,16 +298,17 @@ func TestReactByConvID(t *testing.T) {
 	react := ":cool:"
 
 	// Get last message, we'll react to it
-	messages, err := kbc.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(channel, false)
 	require.NoError(t, err)
 	lastMessageID := messages[0].MsgID
 
 	// Retrieve conversation ID
-	messages, err = kbc.GetTextMessages(channel, false)
+	messages, err = alice.GetTextMessages(channel, false)
+	require.NoError(t, err)
 	convID := messages[0].ConversationID
 
 	// Send the react
-	res, err := kbc.ReactByConvID(convID, lastMessageID, react)
+	res, err := alice.ReactByConvID(convID, lastMessageID, react)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 }
@@ -313,7 +316,7 @@ func TestReactByConvID(t *testing.T) {
 func TestAdvertiseCommands(t *testing.T) {}
 
 func TestListChannels(t *testing.T) {
-	channels, err := kbc.ListChannels(teamChannel.Name)
+	channels, err := alice.ListChannels(teamChannel.Name)
 	require.NoError(t, err)
 	require.Greater(t, len(channels), 0)
 	channelFound := false
@@ -327,13 +330,43 @@ func TestListChannels(t *testing.T) {
 }
 
 func TestJoinAndLeaveChannel(t *testing.T) {
-	_, err := kbc.LeaveChannel(teamChannel.Name, teamChannel.TopicName)
+	_, err := alice.LeaveChannel(teamChannel.Name, teamChannel.TopicName)
 	require.NoError(t, err)
-	_, err = kbc.LeaveChannel(teamChannel.Name, teamChannel.TopicName)
+	_, err = alice.LeaveChannel(teamChannel.Name, teamChannel.TopicName)
 	require.Error(t, err)
-	_, err = kbc.JoinChannel(teamChannel.Name, teamChannel.TopicName)
+	_, err = alice.JoinChannel(teamChannel.Name, teamChannel.TopicName)
 	require.NoError(t, err)
-	_, err = kbc.JoinChannel(teamChannel.Name, teamChannel.TopicName)
+	_, err = alice.JoinChannel(teamChannel.Name, teamChannel.TopicName)
 	// We don't get an error when trying to join an already joined channel
 	require.NoError(t, err)
+}
+
+func TestListenForNewTextMessages(t *testing.T) {
+	dir, err := randomTempDir()
+	require.NoError(t, err)
+	kbLocation, err := prepWorkingDir(dir)
+	require.NoError(t, err)
+	bob, err := Start(RunOptions{KeybaseLocation: kbLocation, HomeDir: dir, Oneshot: config.Bots.Bob1, StartService: true})
+	require.NoError(t, err)
+
+	sub, err := alice.ListenForNewTextMessages()
+	require.NoError(t, err)
+
+	text := "testing listen"
+
+	go func() {
+		for i := 0; i < 5; i++ {
+			time.Sleep(3 * time.Second)
+			_, err := bob.SendMessage(channel, text+" "+strconv.Itoa(i))
+			require.NoError(t, err)
+		}
+	}()
+
+	for i := 0; i < 5; i++ {
+		msg, err := sub.Read()
+		require.NoError(t, err)
+		require.Equal(t, msg.Message.Content.Type, "text")
+		require.Equal(t, msg.Message.Sender.Username, bob.GetUsername())
+		require.Equal(t, msg.Message.Content.Text.Body, text+" "+strconv.Itoa(i))
+	}
 }

--- a/kbchat/kbchat_test.go
+++ b/kbchat/kbchat_test.go
@@ -118,7 +118,7 @@ func deleteWorkingDir(workingDir string) error {
 
 var alice *API
 var config botConfig
-var channel Channel
+var oneOnOneChannel Channel
 var teamChannel Channel
 
 func TestMain(m *testing.M) {
@@ -140,7 +140,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "Error in starting service: %v\n", err)
 	}
 
-	channel = Channel{
+	oneOnOneChannel = Channel{
 		Name: fmt.Sprintf("%s,%s", config.Bots.Alice1.Username, config.Bots.Charlie1.Username),
 	}
 	teamChannel = Channel{
@@ -176,7 +176,7 @@ func TestGetConversations(t *testing.T) {
 }
 
 func TestGetTextMessages(t *testing.T) {
-	messages, err := alice.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
 	require.Greater(t, len(messages), 0)
 }
@@ -185,12 +185,12 @@ func TestSendMessage(t *testing.T) {
 	text := "test SendMessage"
 
 	// Send the message
-	res, err := alice.SendMessage(channel, text)
+	res, err := alice.SendMessage(oneOnOneChannel, text)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
 	// Read it to confirm it sent
-	messages, err := alice.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
 	sentMessage := messages[0]
 	require.Equal(t, sentMessage.Content.Type, "text")
@@ -202,7 +202,8 @@ func TestSendMessageByConvID(t *testing.T) {
 	text := "test SendMessageByConvID"
 
 	// Retrieve conversation ID
-	messages, err := alice.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
+	require.NoError(t, err)
 	convID := messages[0].ConversationID
 
 	// Send the message
@@ -211,7 +212,7 @@ func TestSendMessageByConvID(t *testing.T) {
 	require.Greater(t, res.Result.MsgID, 0)
 
 	// Read it to confirm it sent
-	messages, err = alice.GetTextMessages(channel, false)
+	messages, err = alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
 	sentMessage := messages[0]
 	require.Equal(t, sentMessage.Content.Type, "text")
@@ -223,12 +224,12 @@ func TestSendMessageByTlfName(t *testing.T) {
 	text := "test SendMessageByTlfName"
 
 	// Send the message
-	res, err := alice.SendMessageByTlfName(channel.Name, text)
+	res, err := alice.SendMessageByTlfName(oneOnOneChannel.Name, text)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
 	// Read it to confirm it sent
-	messages, err := alice.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
 	sentMessage := messages[0]
 	require.Equal(t, sentMessage.Content.Type, "text")
@@ -280,12 +281,12 @@ func TestSendAttachmentByTeam(t *testing.T) {
 func TestReactByChannel(t *testing.T) {
 	react := ":cool:"
 	// Get last message, we'll react to it
-	messages, err := alice.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
 	lastMessageID := messages[0].MsgID
 
 	// Send the react
-	res, err := alice.ReactByChannel(channel, lastMessageID, react)
+	res, err := alice.ReactByChannel(oneOnOneChannel, lastMessageID, react)
 	require.NoError(t, err)
 	require.Greater(t, res.Result.MsgID, 0)
 
@@ -296,12 +297,12 @@ func TestReactByConvID(t *testing.T) {
 	react := ":cool:"
 
 	// Get last message, we'll react to it
-	messages, err := alice.GetTextMessages(channel, false)
+	messages, err := alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
 	lastMessageID := messages[0].MsgID
 
 	// Retrieve conversation ID
-	messages, err = alice.GetTextMessages(channel, false)
+	messages, err = alice.GetTextMessages(oneOnOneChannel, false)
 	require.NoError(t, err)
 	convID := messages[0].ConversationID
 
@@ -335,7 +336,7 @@ func TestJoinAndLeaveChannel(t *testing.T) {
 	_, err = alice.JoinChannel(teamChannel.Name, teamChannel.TopicName)
 	require.NoError(t, err)
 	_, err = alice.JoinChannel(teamChannel.Name, teamChannel.TopicName)
-	// We don't get an error when trying to join an already joined channel
+	// We don't get an error when trying to join an already joined oneOnOneChannel
 	require.NoError(t, err)
 }
 
@@ -375,7 +376,7 @@ func TestListenForNewTextMessages(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		time.Sleep(time.Second)
 		message := strconv.Itoa(i)
-		_, err := bob.SendMessage(channel, message)
+		_, err := bob.SendMessage(oneOnOneChannel, message)
 		require.NoError(t, err)
 	}
 }

--- a/kbchat/test_config.example.yaml
+++ b/kbchat/test_config.example.yaml
@@ -20,9 +20,10 @@ config:
   teams:
     acme:
       # A real team that you add your alice1, alice2, and bob1 all into
-      teamname: "acme"
+      name: "acme"
       # The channel to use
-      channel: "mysupercoolchannel"
+      topic_name: "mysupercoolchannel"
     alicesPlayground:
       # a team with alice in it AS ADMIN, but bob or charlie not in team
-      teamname: "alices_playground"
+      name: "alices_playground"
+      topic_name: "alice_time"

--- a/kbchat/test_config.example.yaml
+++ b/kbchat/test_config.example.yaml
@@ -21,6 +21,8 @@ config:
     acme:
       # A real team that you add your alice1, alice2, and bob1 all into
       teamname: "acme"
+      # The channel to use
+      channel: "mysupercoolchannel"
     alicesPlayground:
       # a team with alice in it AS ADMIN, but bob or charlie not in team
       teamname: "alices_playground"

--- a/kbchat/test_config.example.yaml
+++ b/kbchat/test_config.example.yaml
@@ -2,10 +2,10 @@
 
 config:
   bots:
-    alice1:
+    alice:
       username: "alice"
       paperkey: "foo bar car..."
-    bob1:
+    bob:
       username: "bob"
       paperkey: "one two three four..."
   teams:

--- a/kbchat/test_config.example.yaml
+++ b/kbchat/test_config.example.yaml
@@ -3,27 +3,14 @@
 config:
   bots:
     alice1:
-      # Alice should have an active Stellar account with a little bit of XLM in it
       username: "alice"
       paperkey: "foo bar car..."
-    alice2:
-      username: "alice"                # should be the same username as alice1 but...
-      paperkey: "yo there paperkey..." # ...this should be a DIFFERENT paperkey than the one for alice1
     bob1:
-      # Bob should have an active Stellar account with a little bit of XLM in it
       username: "bob"
       paperkey: "one two three four..."
-    charlie1:
-      # Charlie should be an account that has not accepted the Stellar disclaimer yet
-      username: "charlie"
-      paperkey: "get this bread..."
   teams:
     acme:
-      # A real team that you add your alice1, alice2, and bob1 all into
+      # A real team that you add your alice1 and bob1 into
       name: "acme"
       # The channel to use
       topicname: "mysupercoolchannel"
-    alicesPlayground:
-      # a team with alice in it AS ADMIN, but bob or charlie not in team
-      name: "alices_playground"
-      topicname: "alice_time"

--- a/kbchat/test_config.example.yaml
+++ b/kbchat/test_config.example.yaml
@@ -22,8 +22,8 @@ config:
       # A real team that you add your alice1, alice2, and bob1 all into
       name: "acme"
       # The channel to use
-      topic_name: "mysupercoolchannel"
+      topicname: "mysupercoolchannel"
     alicesPlayground:
       # a team with alice in it AS ADMIN, but bob or charlie not in team
       name: "alices_playground"
-      topic_name: "alice_time"
+      topicname: "alice_time"

--- a/kbchat/test_utils.go
+++ b/kbchat/test_utils.go
@@ -1,0 +1,54 @@
+package kbchat
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func randomString(t *testing.T) string {
+	bytes := make([]byte, 16)
+	_, err := rand.Read(bytes)
+	require.NoError(t, err)
+	return hex.EncodeToString(bytes)
+}
+
+func randomTempDir(t *testing.T) string {
+	return path.Join(os.TempDir(), "keybase_bot_"+randomString(t))
+}
+
+func whichKeybase(t *testing.T) string {
+	cmd := exec.Command("which", "keybase")
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	location := strings.TrimSpace(string(out))
+	return location
+}
+
+func copyFile(t *testing.T, source, dest string) {
+	sourceData, err := ioutil.ReadFile(source)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(dest, sourceData, 0777)
+	require.NoError(t, err)
+}
+
+// Creates the working directory and copies over the keybase binary in PATH.
+// We do this to avoid any version mismatch issues.
+func prepWorkingDir(t *testing.T, workingDir string) string {
+	kbLocation := whichKeybase(t)
+
+	err := os.Mkdir(workingDir, 0777)
+	require.NoError(t, err)
+	kbDestination := path.Join(workingDir, "keybase")
+
+	copyFile(t, kbLocation, kbDestination)
+
+	return kbDestination
+}

--- a/kbchat/types.go
+++ b/kbchat/types.go
@@ -11,7 +11,7 @@ type Channel struct {
 	Name        string `json:"name"`
 	Public      bool   `json:"public"`
 	TopicType   string `json:"topic_type"`
-	TopicName   string `json:"topic_name" yaml:"topic_name"`
+	TopicName   string `json:"topic_name"`
 	MembersType string `json:"members_type"`
 }
 

--- a/kbchat/types.go
+++ b/kbchat/types.go
@@ -129,12 +129,12 @@ type Advertisement struct {
 }
 
 type Error struct {
-	Code int `json:"code"`
+	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
 
 type JoinChannel struct {
-	Error Error `json:"error"`
+	Error  Error             `json:"error"`
 	Result JoinChannelResult `json:"result"`
 }
 
@@ -142,9 +142,18 @@ type JoinChannelResult struct {
 	RateLimit []RateLimit `json:"ratelimits"`
 }
 
+type LeaveChannel struct {
+	Error  Error              `json:"error"`
+	Result LeaveChannelResult `json:"result"`
+}
+
+type LeaveChannelResult struct {
+	RateLimit []RateLimit `json:"ratelimits"`
+}
+
 type RateLimit struct {
-	Tank string `json:"tank"`
-	Capacity int `json:"capacity"`
-	Reset int `json:"reset"`
-	Gas int `json:"gas"`
+	Tank     string `json:"tank"`
+	Capacity int    `json:"capacity"`
+	Reset    int    `json:"reset"`
+	Gas      int    `json:"gas"`
 }

--- a/kbchat/types.go
+++ b/kbchat/types.go
@@ -11,7 +11,7 @@ type Channel struct {
 	Name        string `json:"name"`
 	Public      bool   `json:"public"`
 	TopicType   string `json:"topic_type"`
-	TopicName   string `json:"topic_name"`
+	TopicName   string `json:"topic_name" yaml:"topic_name"`
 	MembersType string `json:"members_type"`
 }
 


### PR DESCRIPTION
Adds tests for most kbchat functionality. The only functions that aren't tested are:
- `GetWalletTxDetails` (we need some more wallet functionality before we can really test it)
- `AdvertiseCommands` (I'm not super familiar with this function, so I'm not exactly sure how to test it)

I think the set of tested functions now give us a good level of confidence to start refactoring types.