### PR TITLE
Use bufio.Reader instead of Scanner for most API calls

### DIFF
--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -177,11 +177,7 @@ func (a *API) GetConversations(unreadOnly bool) ([]Conversation, error) {
 	}
 
 	var inbox Inbox
-	inboxRaw, err := output.ReadBytes('\n')
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(inboxRaw, &inbox); err != nil {
+	if err := json.Unmarshal(output, &inbox); err != nil {
 		return nil, err
 	}
 	return inbox.Result.Convs, nil
@@ -202,11 +198,7 @@ func (a *API) GetTextMessages(channel Channel, unreadOnly bool) ([]Message, erro
 
 	var thread Thread
 
-	messagesRaw, err := output.ReadBytes('\n')
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(messagesRaw, &thread); err != nil {
+	if err := json.Unmarshal(output, &thread); err != nil {
 		return nil, fmt.Errorf("unable to decode thread: %s", err.Error())
 	}
 
@@ -267,7 +259,7 @@ func (a *API) doSend(arg interface{}) (response SendResponse, err error) {
 	return response, nil
 }
 
-func (a *API) doFetch(apiInput string) (*bufio.Reader, error) {
+func (a *API) doFetch(apiInput string) ([]byte, error) {
 	a.Lock()
 	defer a.Unlock()
 
@@ -278,9 +270,12 @@ func (a *API) doFetch(apiInput string) (*bufio.Reader, error) {
 	if _, err := io.WriteString(input, apiInput); err != nil {
 		return nil, err
 	}
-	// output.ReadString('\n')
+	byteOutput, err := output.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
 
-	return output, nil
+	return byteOutput, nil
 }
 
 func (a *API) SendMessage(channel Channel, body string) (SendResponse, error) {
@@ -605,12 +600,7 @@ func (a *API) ListChannels(teamName string) ([]string, error) {
 	}
 
 	var channelsList ChannelsList
-	inboxRaw, err := output.ReadBytes('\n')
-	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(inboxRaw, &channelsList); err != nil {
+	if err := json.Unmarshal(output, &channelsList); err != nil {
 		return nil, err
 	}
 
@@ -631,11 +621,7 @@ func (a *API) JoinChannel(teamName string, channelName string) (JoinChannelResul
 	}
 
 	joinChannel := JoinChannel{}
-	joinRaw, err := output.ReadBytes('\n')
-	if err != nil {
-		return empty, err
-	}
-	err = json.Unmarshal(joinRaw, &joinChannel)
+	err = json.Unmarshal(output, &joinChannel)
 	if err != nil {
 		return empty, fmt.Errorf("failed to parse output from keybase team api: %v", err)
 	}


### PR DESCRIPTION
For conversations with long histories, `bufio.Scanner` is not able to parse the entire output in one scan. As per the [Go docs' reccomendation](https://golang.org/pkg/bufio/#Scanner):

> Programs that need more control over error handling or large tokens, or must run sequential scans on a reader, should use bufio.Reader instead. 

I opted to use `bufio.Reader` instead.

This change only affects functions like `GetTextMessages` and sends; the listen functionality still uses scanners because `bufio.Scanner` seems perfectly capable of handling message output from a listen. This could change in the future and may be worth revisiting, but I figured I wouldn't change what isn't broken.