### PR TITLE
Remove username function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ func main() {
 		fail("Error creating API: %s", err.Error())
 	}
 
-	tlfName := fmt.Sprintf("%s,%s", kbc.Username(), "kb_monbot")
+	tlfName := fmt.Sprintf("%s,%s", kbc.GetUsername(), "kb_monbot")
 	fmt.Printf("saying hello on conversation: %s\n", tlfName)
 	if err = kbc.SendMessageByTlfName(tlfName, "hello!"); err != nil {
 		fail("Error sending message; %s", err.Error())

--- a/examples/helloworld/helloworld.go
+++ b/examples/helloworld/helloworld.go
@@ -25,7 +25,7 @@ func main() {
 		fail("Error creating API: %s", err.Error())
 	}
 
-	tlfName := fmt.Sprintf("%s,%s", kbc.Username(), "kb_monbot")
+	tlfName := fmt.Sprintf("%s,%s", kbc.GetUsername(), "kb_monbot")
 	fmt.Printf("saying hello on conversation: %s\n", tlfName)
 	if _, err = kbc.SendMessageByTlfName(tlfName, "hello!"); err != nil {
 		fail("Error sending message; %s", err.Error())

--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -422,10 +422,6 @@ func (a *API) AdvertiseCommands(ad Advertisement) (SendResponse, error) {
 	return a.doSend(newAdvertiseMsgArg(ad))
 }
 
-func (a *API) Username() string {
-	return a.username
-}
-
 // SubscriptionMessage contains a message and conversation object
 type SubscriptionMessage struct {
 	Message      Message


### PR DESCRIPTION
We have `GetUsername()` and `Username()`. It seemed redundant, so I opted to just use `GetUsername()`.