### PR TITLE
5 secs is too little

### DIFF
--- a/kbchat/kbchat.go
+++ b/kbchat/kbchat.go
@@ -228,7 +228,7 @@ func (a *API) getUsername(runOpts RunOptions) (username string, err error) {
 		if err != nil {
 			return "", err
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(15 * time.Second):
 		return "", errors.New("unable to run Keybase command")
 	}
 


### PR DESCRIPTION
Isn't there a better way than to hardcode timouts amindst the code?

workaround for: https://github.com/keybase/bot-sshca/issues/91

My setup:

- Raspberry Pi B V1.2
- Location: Colombia
- Normal internet latency during corona times