### PR TITLE
Support gomodules for type compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ types:
 	@mkdir -p kbchat/types/gregor1
 	@mkdir -p kbchat/types/chat1
 	@mkdir -p kbchat/types/stellar1
-	$(AVDLC) -b -l go -t -o kbchat/types/keybase1 $(PROTOCOL_PATH)/avdl/keybase1/*.avdl
-	$(AVDLC) -b -l go -t -o kbchat/types/gregor1 $(PROTOCOL_PATH)/avdl/gregor1/*.avdl
-	$(AVDLC) -b -l go -t -o kbchat/types/chat1 $(PROTOCOL_PATH)/avdl/chat1/*.avdl
-	$(AVDLC) -b -l go -t -o kbchat/types/stellar1 $(PROTOCOL_PATH)/avdl/stellar1/*.avdl
+	$(AVDLC) -b -l go -t -m -o kbchat/types/keybase1 $(PROTOCOL_PATH)/avdl/keybase1/*.avdl
+	$(AVDLC) -b -l go -t -m -o kbchat/types/gregor1 $(PROTOCOL_PATH)/avdl/gregor1/*.avdl
+	$(AVDLC) -b -l go -t -m -o kbchat/types/chat1 $(PROTOCOL_PATH)/avdl/chat1/*.avdl
+	$(AVDLC) -b -l go -t -m -o kbchat/types/stellar1 $(PROTOCOL_PATH)/avdl/stellar1/*.avdl
 	goimports -w ./kbchat/types/
 
 clean:

--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ cd ../../go-keybase-chat-bot
 make
 ```
 
+You can optionally specify a directory to the client protocol when making the types if `client` and `go-keybase-chat-bot` are not in the same directory.
+```shell
+make PROTOCOL_PATH=path/to/client/protocol
+```
+
 Should you need to remove all the types for some reason, you can run `make clean`.
 
 ### Testing


### PR DESCRIPTION
Allows types to be compiled in a non-GOPATH directory

Depends on https://github.com/keybase/node-avdl-compiler/pull/54 and https://github.com/keybase/client/pull/24023