### PR TITLE
Make sure msg.Msg exists before checking content type

### DIFF
--- a/kbchat/chat.go
+++ b/kbchat/chat.go
@@ -114,7 +114,7 @@ func (a *API) GetTextMessages(channel chat1.ChatChannel, unreadOnly bool) ([]cha
 
 	var res []chat1.MsgSummary
 	for _, msg := range thread.Result.Messages {
-		if msg.Msg.Content.TypeName == "text" {
+		if msg.Msg != nil && msg.Msg.Content.TypeName == "text" {
 			res = append(res, *msg.Msg)
 		}
 	}


### PR DESCRIPTION
This fixes a bug in `(*API).GetTextMessages` where a nil pointer exception occurs when an already-exploded message is fetched from a conversation. After a message has exploded, the api returns an `Error` instead of a `Msg`.